### PR TITLE
Add --no-optional-locks to git status command

### DIFF
--- a/lime.plugin.zsh
+++ b/lime.plugin.zsh
@@ -140,7 +140,7 @@ prompt_lime_git_dirty() {
     git_status_options+=(--ignore-submodules=dirty)
   fi
 
-  [ -n "$(command git status $git_status_options)" ] && echo -n '*'
+  [ -n "$(command git --no-optional-locks status $git_status_options)" ] && echo -n '*'
 }
 
 prompt_lime_symbol() {


### PR DESCRIPTION
## Summary
- Add `--no-optional-locks` option to `git status` command in `prompt_lime_git_dirty` function

## Description
The `--no-optional-locks` option prevents git from acquiring optional locks when running `git status`. This is useful for prompts that run `git status` frequently, as it avoids lock file conflicts (`.git/index.lock`) with other concurrent git operations.

## Test plan
- [ ] Verify the prompt displays correctly with the new option
- [ ] Confirm no lock conflicts occur during concurrent git operations